### PR TITLE
new feature: command line option for bind address

### DIFF
--- a/bin/tileserver-gl-light.js
+++ b/bin/tileserver-gl-light.js
@@ -8,6 +8,11 @@ var opts = require('nomnom')
     position: 0,
     help: "MBTiles path"
   })
+  .option('bind', {
+    abbr: 'b',
+    default: "::",
+    help: 'Bind address'
+  })
   .option('port', {
     abbr: 'p',
     default: 8080,
@@ -24,6 +29,7 @@ var opts = require('nomnom')
 
 return require('../src/server')({
   installationPath: path.dirname(path.dirname(module.filename)),
+  bind: opts.bind,
   port: opts.port,
   mbtilesFile: opts.mbtiles
 });

--- a/src/server.js
+++ b/src/server.js
@@ -159,7 +159,7 @@ module.exports = function(opts, callback) {
   // serve web presentations
   app.use('/', express.static(path.join(__dirname, '../public/resources')));
 
-  var server = app.listen(process.env.PORT || opts.port, function() {
+  var server = app.listen(process.env.PORT || opts.port, process.env.BIND || opts.bind, function() {
     console.log('Listening at http://%s:%d/',
                 this.address().address, this.address().port);
 


### PR DESCRIPTION
Comamnd line option
`-b, --bind`
to specify the network interface to which to bind (default is "every interface" as of IPv6: "::")

Requested in: osm2vectortiles/tileserver-gl-light/issues/4
